### PR TITLE
[LTB-31] Remove `-hide-packages base`

### DIFF
--- a/code/base/hpack/definitions.yaml
+++ b/code/base/hpack/definitions.yaml
@@ -43,7 +43,6 @@ _definitions:
 
     - &ghc-options
         - -Wall
-        - -hide-package base
 
 
   _utils:


### PR DESCRIPTION
Stack says that this option is never needed because Cabal hides packages
anyway. And indeed it seems that nothing breaks without this option.