### PR TITLE
[LTB-17] CLI options parsers for loot-config

### DIFF
--- a/code/config/lib/Loot/Config.hs
+++ b/code/config/lib/Loot/Config.hs
@@ -1,7 +1,4 @@
-{- This Source Code Form is subject to the terms of the Mozilla Public
- - License, v. 2.0. If a copy of the MPL was not distributed with this
- - file, You can obtain one at http://mozilla.org/MPL/2.0/.
- -}
+{- SPDX-License-Identifier: MPL-2.0 -}
 
 {-# LANGUAGE DataKinds     #-}
 {-# LANGUAGE TypeOperators #-}

--- a/code/config/lib/Loot/Config.hs
+++ b/code/config/lib/Loot/Config.hs
@@ -22,8 +22,8 @@ import Lens.Micro ((?~))
 
 import Loot.Config.CLI (OptParser, (.::), (.:<), (.<>))
 import Loot.Config.Lens
-import Loot.Config.Record ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, finalise, option,
-                           sub)
+import Loot.Config.Record ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, complement,
+                           finalise, finaliseDeferredUnsafe, option, sub, upcast)
 import Loot.Config.Yaml ()
 
 

--- a/code/config/lib/Loot/Config.hs
+++ b/code/config/lib/Loot/Config.hs
@@ -10,6 +10,7 @@
 module Loot.Config
        ( module Loot.Config.Record
        , module Loot.Config.Lens
+       , module Loot.Config.CLI
 
        , Config
        , PartialConfig
@@ -19,6 +20,7 @@ module Loot.Config
 
 import Lens.Micro ((?~))
 
+import Loot.Config.CLI (OptParser, (.::), (.:<), (.<>))
 import Loot.Config.Lens
 import Loot.Config.Record ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, finalise, option,
                            sub)

--- a/code/config/lib/Loot/Config/CLI.hs
+++ b/code/config/lib/Loot/Config/CLI.hs
@@ -1,0 +1,92 @@
+{- This Source Code Form is subject to the terms of the Mozilla Public
+ - License, v. 2.0. If a copy of the MPL was not distributed with this
+ - file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ -}
+
+{-# OPTIONS_GHC -fno-warn-orphans #-}
+
+{-# LANGUAGE DataKinds        #-}
+{-# LANGUAGE KindSignatures   #-}
+{-# LANGUAGE OverloadedLabels #-}
+{-# LANGUAGE TypeOperators    #-}
+{-# LANGUAGE TypeFamilies #-}
+
+-- | Utilities for reading configuration from command-line parameters.
+module Loot.Config.CLI
+       ( OptParser
+       , (.::)
+       , (.:<)
+       , (.<>)
+       ) where
+
+import Data.Vinyl (Label, Rec ((:&), RNil), type (<:))
+import Options.Applicative (Parser, auto, long, strOption, switch, value)
+import qualified Options.Applicative as Opt
+import Data.Default (Default (def))
+
+import Loot.Config.Record ((:::), (::<), ConfigKind (Partial), ConfigRec, HasOption, HasSub,
+                           Item (ItemOptionP, ItemSub), ItemKind, option, sub)
+
+
+-- | Type alias for options parser
+type OptParser cfg = Parser (ConfigRec 'Partial cfg)
+
+-- | Combinator which declares a config parser which parses one config
+-- option, leaving other options empty.
+(.::)
+    :: forall l is v. (HasOption l is v, Default (ConfigRec 'Partial is))
+    => Label l
+    -> Parser v
+    -> OptParser is
+l .:: p = (\v -> def & option l .~ Just v) <$> p
+infixr 6 .::
+
+-- | Combinator which declares a config parser which parses one
+-- subsection, leaving other options empty.
+(.:<)
+    :: forall l is us. (HasSub l is us, Default (ConfigRec 'Partial is))
+    => Label l
+    -> OptParser us
+    -> OptParser is
+l .:< p = (\us -> def & sub l .~ us) <$> p
+infixr 6 .:<
+
+{-|
+Combines two partial config parsers.
+It is intended to use with @OverloadedLabels@ and combinators
+'.::' and '.:<' to build partial CLI parsers for config records.
+
+Example: here is the config type:
+
+@
+type Config =
+  '[ "mda" ::: Int
+   , "heh" ::: Bool
+   , "taks" ::<
+       '[ "chto" ::: String
+        , "tut" ::: Integer
+        , "u_nas" ::: Bool
+        ]
+   ]
+@
+
+And here is a valid parser for this config:
+
+@
+cfgParser :: OptParser Config
+cfgParser =
+    #heh  .:: switch (long "heh") .<>
+    #taks .:<
+       (#chto  .:: strOption (long "chto") .<>
+        #u_nas .:: switch (long "u_nas"))
+@
+
+Note that options "mda" and "taks.tut" are omitted
+from parser's definition. This means that these options
+will not be included in the partial config produced by the parser.
+-}
+(.<>)
+    :: Semigroup (ConfigRec 'Partial is)
+    => OptParser is -> OptParser is -> OptParser is
+p .<> q = (<>) <$> p <*> q
+infixr 5 .<>

--- a/code/config/lib/Loot/Config/CLI.hs
+++ b/code/config/lib/Loot/Config/CLI.hs
@@ -1,7 +1,4 @@
-{- This Source Code Form is subject to the terms of the Mozilla Public
- - License, v. 2.0. If a copy of the MPL was not distributed with this
- - file, You can obtain one at http://mozilla.org/MPL/2.0/.
- -}
+{- SPDX-License-Identifier: MPL-2.0 -}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/code/config/lib/Loot/Config/CLI.hs
+++ b/code/config/lib/Loot/Config/CLI.hs
@@ -1,12 +1,8 @@
-{- SPDX-License-Identifier: MPL-2.0 -}
+ -- SPDX-License-Identifier: MPL-2.0
 
-{-# OPTIONS_GHC -fno-warn-orphans #-}
-
-{-# LANGUAGE DataKinds        #-}
-{-# LANGUAGE KindSignatures   #-}
-{-# LANGUAGE OverloadedLabels #-}
-{-# LANGUAGE TypeOperators    #-}
-{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE DataKinds     #-}
+{-# LANGUAGE TypeFamilies  #-}
+{-# LANGUAGE TypeOperators #-}
 
 -- | Utilities for reading configuration from command-line parameters.
 module Loot.Config.CLI
@@ -16,13 +12,11 @@ module Loot.Config.CLI
        , (.<>)
        ) where
 
-import Data.Vinyl (Label, Rec ((:&), RNil), type (<:))
-import Options.Applicative (Parser, auto, long, strOption, switch, value)
-import qualified Options.Applicative as Opt
 import Data.Default (Default (def))
+import Data.Vinyl (Label)
+import Options.Applicative (Parser, optional)
 
-import Loot.Config.Record ((:::), (::<), ConfigKind (Partial), ConfigRec, HasOption, HasSub,
-                           Item (ItemOptionP, ItemSub), ItemKind, option, sub)
+import Loot.Config.Record (ConfigKind (Partial), ConfigRec, HasOption, HasSub, option, sub)
 
 
 -- | Type alias for options parser
@@ -35,7 +29,7 @@ type OptParser cfg = Parser (ConfigRec 'Partial cfg)
     => Label l
     -> Parser v
     -> OptParser is
-l .:: p = (\v -> def & option l .~ Just v) <$> p
+l .:: p = (\v -> def & option l .~ v) <$> optional p
 infixr 6 .::
 
 -- | Combinator which declares a config parser which parses one

--- a/code/config/lib/Loot/Config/Lens.hs
+++ b/code/config/lib/Loot/Config/Lens.hs
@@ -1,3 +1,5 @@
+{- SPDX-License-Identifier: MPL-2.0 -}
+
 {-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}

--- a/code/config/lib/Loot/Config/Lens.hs
+++ b/code/config/lib/Loot/Config/Lens.hs
@@ -14,6 +14,7 @@ module Loot.Config.Lens
     ) where
 
 import Data.Vinyl (Label (..))
+import Data.Vinyl.TypeLevel (type (++))
 import GHC.TypeLits (ErrorMessage (Text), Symbol, TypeError)
 
 import Loot.Base.HasLens (HasLens (..))
@@ -22,12 +23,6 @@ import Loot.Config.Record
 ----------------------------------------------------------------------------
 -- Constraints
 ----------------------------------------------------------------------------
-
--- Because there is no publicly availble type family for list concatenation.
-type family (++) (as :: [k]) (bs :: [k]) :: [k] where
-    (++) a '[] = a
-    (++) '[] b = b
-    (++) (a ': as) bs = a ': (as ++ bs)
 
 type family RevList (a :: [k]) :: [k] where
     RevList '[] = '[]

--- a/code/config/lib/Loot/Config/Record.hs
+++ b/code/config/lib/Loot/Config/Record.hs
@@ -43,8 +43,8 @@ module Loot.Config.Record
        , sub
        ) where
 
-import Data.Validation (Validation (Failure, Success), toEither)
 import Data.Default (Default (..))
+import Data.Validation (Validation (Failure, Success), toEither)
 import Data.Vinyl (Label, Rec ((:&), RNil))
 import Data.Vinyl.Lens (RecElem, rlens)
 import Data.Vinyl.TypeLevel (RIndex)

--- a/code/config/lib/Loot/Config/Record.hs
+++ b/code/config/lib/Loot/Config/Record.hs
@@ -35,6 +35,7 @@ module Loot.Config.Record
        , finalise
        , finaliseDeferredUnsafe
        , complement
+       , upcast
 
        , HasOption
        , option
@@ -46,7 +47,7 @@ module Loot.Config.Record
 import Data.Default (Default (..))
 import Data.Validation (Validation (Failure, Success), toEither)
 import Data.Vinyl (Label, Rec ((:&), RNil))
-import Data.Vinyl.Lens (RecElem, rlens)
+import Data.Vinyl.Lens (RecElem, rlens, rreplace, type (<:))
 import Data.Vinyl.TypeLevel (RIndex)
 import GHC.TypeLits (ErrorMessage ((:<>:), ShowType, Text), KnownSymbol, Symbol, TypeError,
                      symbolVal)
@@ -191,6 +192,14 @@ complement (ItemOptionP opt :& ps) (ItemOptionF sup :& fs)
     = ItemOptionF (fromMaybe sup opt) :& complement ps fs
 complement (ItemSub part :& ps) (ItemSub final :& fs)
     = ItemSub (complement part final) :& complement ps fs
+
+-- | Cast partial config to another partial config which is
+-- a superset of the former.
+upcast
+    :: (Monoid (ConfigRec 'Partial xs), ys <: xs)
+    => ConfigRec 'Partial ys
+    -> ConfigRec 'Partial xs
+upcast ys = rreplace ys mempty
 
 -----------------------
 -- Configuration lenses

--- a/code/config/lib/Loot/Config/Record.hs
+++ b/code/config/lib/Loot/Config/Record.hs
@@ -1,7 +1,4 @@
-{- This Source Code Form is subject to the terms of the Mozilla Public
- - License, v. 2.0. If a copy of the MPL was not distributed with this
- - file, You can obtain one at http://mozilla.org/MPL/2.0/.
- -}
+{- SPDX-License-Identifier: MPL-2.0 -}
 
 {-# LANGUAGE ConstraintKinds      #-}
 {-# LANGUAGE DataKinds            #-}

--- a/code/config/lib/Loot/Config/Yaml.hs
+++ b/code/config/lib/Loot/Config/Yaml.hs
@@ -1,7 +1,4 @@
-{- This Source Code Form is subject to the terms of the Mozilla Public
- - License, v. 2.0. If a copy of the MPL was not distributed with this
- - file, You can obtain one at http://mozilla.org/MPL/2.0/.
- -}
+{- SPDX-License-Identifier: MPL-2.0 -}
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 

--- a/code/config/package.yaml
+++ b/code/config/package.yaml
@@ -11,6 +11,7 @@ library:
     - data-default
     - loot-base
     - microlens
+    - optparse-applicative
     - validation
     - vinyl
 


### PR DESCRIPTION
Added combinators for defining CLI options parsers for partial configs using `optparse-applicative`.
This approach has been chosen instead of deriving parsers automatically from the config type, because:
- Some parts of config may not be intended to be provided via CLI (like genesis distribution)
- Options of one type (like `Text`) might have completely different parsers (like path to file and network address)
- Descriptions, default values, etc. should be provided for CLI parsers, and we arguably don't want to encode all this stuff in config type.