### PR TITLE
[DSCP-344] Fix CLI parser overriding behavior

### DIFF
--- a/code/config/lib/Loot/Config.hs
+++ b/code/config/lib/Loot/Config.hs
@@ -17,7 +17,7 @@ module Loot.Config
 
 import Lens.Micro ((?~))
 
-import Loot.Config.CLI (OptParser, (.::), (.:<), (.<>))
+import Loot.Config.CLI
 import Loot.Config.Lens
 import Loot.Config.Record ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, complement,
                            finalise, finaliseDeferredUnsafe, option, sub, upcast)

--- a/code/config/lib/Loot/Config/CLI.hs
+++ b/code/config/lib/Loot/Config/CLI.hs
@@ -6,44 +6,28 @@
 
 -- | Utilities for reading configuration from command-line parameters.
 module Loot.Config.CLI
-       ( OptParser
+       ( ModParser
+       , OptModParser
+       , modifying
+       , setP
+       , (<.>)
        , (.::)
+       , (%::)
        , (.:<)
-       , (.<>)
        ) where
 
-import Data.Default (Default (def))
 import Data.Vinyl (Label)
+import Lens.Micro (ASetter')
 import Options.Applicative (Parser, optional)
 
 import Loot.Config.Record (ConfigKind (Partial), ConfigRec, HasOption, HasSub, option, sub)
 
-
--- | Type alias for options parser
-type OptParser cfg = Parser (ConfigRec 'Partial cfg)
-
--- | Combinator which declares a config parser which parses one config
--- option, leaving other options empty.
-(.::)
-    :: forall l is v. (HasOption l is v, Default (ConfigRec 'Partial is))
-    => Label l
-    -> Parser v
-    -> OptParser is
-l .:: p = (\v -> def & option l .~ v) <$> optional p
-infixr 6 .::
-
--- | Combinator which declares a config parser which parses one
--- subsection, leaving other options empty.
-(.:<)
-    :: forall l is us. (HasSub l is us, Default (ConfigRec 'Partial is))
-    => Label l
-    -> OptParser us
-    -> OptParser is
-l .:< p = (\us -> def & sub l .~ us) <$> p
-infixr 6 .:<
+-- | Type for a parser which yields a modifier function instead of a
+-- value
+type ModParser a = Parser (a -> a)
 
 {-|
-Combines two partial config parsers.
+Combines two modifier parsers.
 It is intended to use with @OverloadedLabels@ and combinators
 '.::' and '.:<' to build partial CLI parsers for config records.
 
@@ -64,11 +48,11 @@ type Config =
 And here is a valid parser for this config:
 
 @
-cfgParser :: OptParser Config
+cfgParser :: OptModParser Config
 cfgParser =
-    #heh  .:: switch (long "heh") .<>
+    #heh  .:: switch (long "heh") <.>
     #taks .:<
-       (#chto  .:: strOption (long "chto") .<>
+       (#chto  .:: strOption (long "chto") <.>
         #u_nas .:: switch (long "u_nas"))
 @
 
@@ -76,8 +60,48 @@ Note that options "mda" and "taks.tut" are omitted
 from parser's definition. This means that these options
 will not be included in the partial config produced by the parser.
 -}
-(.<>)
-    :: Semigroup (ConfigRec 'Partial is)
-    => OptParser is -> OptParser is -> OptParser is
-p .<> q = (<>) <$> p <*> q
-infixr 5 .<>
+(<.>) :: ModParser a -> ModParser a -> ModParser a
+p <.> q = (.) <$> p <*> q
+infixl 5 <.>
+
+-- | Creates a trivial modifying parser which just replaces original
+-- value with given one.
+modifying :: Parser a -> ModParser a
+modifying = fmap const
+
+-- | Creates a parser which sets a given value using a `Setter` (usually a
+-- `Lens` to another type).
+setP :: ASetter' a b -> Parser b -> ModParser a
+setP = fmap . set
+
+-- | Type alias for a parser which yields config modifier
+type OptModParser cfg = ModParser (ConfigRec 'Partial cfg)
+
+-- | Combinator which declares a config parser which parses one config
+-- option, leaving other options empty.
+(.::)
+    :: forall l is v. HasOption l is v
+    => Label l
+    -> Parser v
+    -> OptModParser is
+l .:: p = (\mv -> option l %~ (mv <|>)) <$> optional p
+infixr 6 .::
+
+-- | Combinator which declares a config parser which modifies one config
+-- option, not touching other options.
+(%::)
+    :: forall l is v. HasOption l is v
+    => Label l
+    -> ModParser v
+    -> OptModParser is
+l %:: p = (\f -> option l %~ fmap f) <$> p
+
+-- | Combinator which declares a config parser which parses one
+-- subsection, leaving other options empty.
+(.:<)
+    :: forall l is us. (HasSub l is us)
+    => Label l
+    -> OptModParser us
+    -> OptModParser is
+l .:< p = (\uf cfg -> cfg & sub l %~ uf) <$> p
+infixr 6 .:<


### PR DESCRIPTION
Instead of yielding the config value itself, the parsers now yield
a function which modifies values in config.

This is done in order to allow for partial overriding of fields in record types inside config.