### PR TITLE
[DSCP-361] fix corrupted syslog output on stderr

### DIFF
--- a/stack.yaml
+++ b/stack.yaml
@@ -1,5 +1,9 @@
 resolver: snapshot.yaml
 
+extra-deps:
+- git: https://github.com/pasqu4le/hslogger.git
+  commit: 28d5f0cf220a1b7162eaa1535e72e6cad2362ee4
+
 packages:
   - code/base
   - code/config


### PR DESCRIPTION
This PR solves the problem of scrambled text in stderr output by `loot-log`'s Syslogger, by using a fork of `hslogger` that does this is a thread-safe way.

NOTE: this was born out of a Disciplina issue, but it is not necessary to solve it. Nevertheless it is probably a good idea to have this fixed in `lootbox` itself as well