### PR TITLE
[LTB-16] add support for sum types

### DIFF
--- a/code/config/README.md
+++ b/code/config/README.md
@@ -31,7 +31,7 @@ type Options =
          ]
      , "connection" ::+
         '[ ftpAuth ::-
-           '[ userName ::: String 
+           '[ userName ::: String
             , password ::: String
             , doRetry ::: Bool
             ]
@@ -39,7 +39,8 @@ type Options =
            '[ doRetry ::: Bool
             ]
          , https ::-
-           '[ userName ::: String 
+           '[ userName ::: String
+            , password ::: String
             ]
          ]
      ]
@@ -99,21 +100,25 @@ To address this from your code you can also use the `selection` lens, that works
 ...
 ```
 
-Please note that a `tree` will need all it's children to be `branch`es, so if you specify another item it will be converted, for instance in the example above we could have specified the "https" "connection" as
+Please note that a `tree` `selection` only specifies what `branch` (`::-`) to use, so if you put non-`branch` items inside of a `tree` they will be treated as in every other place.
 
-```haskell
-...
-         , https ::: String
-...
-```
+You can use this, for instance, to factor out the options that are common to every `branch` of a `tree`. In the example above if you realize that also "ftpAnon" needs a "password", you could do:
 
-but that would have been the same as defining:
-
-```haskell
+```yaml
 ...
-         , https ::-
-           '[ https ::: String 
+     , "connection" ::+
+        '[ ftpAuth ::-
+           '[ userName ::: String
+            , doRetry ::: Bool
             ]
+         , ftpAnon ::-
+           '[ doRetry ::: Bool
+            ]
+         , https ::-
+           '[ userName ::: String
+            ]
+         , password ::: String
+         ]
 ...
 ```
 

--- a/code/config/README.md
+++ b/code/config/README.md
@@ -90,6 +90,15 @@ connection:
 ...
 ```
 
+To address this from your code you can also use the `selection` lens, that works for any `tree`. For instance these 2 lines are equivalent:
+
+```haskell
+...
+    & tree #connection . option #connectionType ?~ "branchA"
+    & tree #connection . selection ?~ "branchA"
+...
+```
+
 Please note that a `tree` will need all it's children to be `branch`es, so if you specify another item it will be converted, for instance in the example above we could have specified the "https" "connection" as
 
 ```haskell

--- a/code/config/README.md
+++ b/code/config/README.md
@@ -17,7 +17,7 @@ You will need at least the following extensions:
 And the following imports:
 
 ```haskell
-import Loot.Config ((:::), (::<), ConfigKind (Final, Partial), ConfigRec)
+import Loot.Config ((:::), (::<), (::+), (::-), ConfigKind (Final, Partial), ConfigRec)
 ```
 
 Declare the structure of your configuration:
@@ -29,6 +29,19 @@ type Options =
         '[ "host" ::: String
          , "port" ::: Word16
          ]
+     , "connection" ::+
+        '[ ftpAuth ::-
+           '[ userName ::: String 
+            , password ::: String
+            , doRetry ::: Bool
+            ]
+         , ftpAnon ::-
+           '[ doRetry ::: Bool
+            ]
+         , https ::-
+           '[ userName ::: String 
+            ]
+         ]
      ]
 ```
 
@@ -36,6 +49,8 @@ Simply put:
 
 * `:::` declares a new configuration option
 * `::<` declares a new subsection
+* `::+` declares a new tree of available subsection
+* `::-` declares an available branch of a tree
 
 Now you can get two data types:
 
@@ -55,10 +70,47 @@ If types of all your options have `FromJSON` instances, the resulting partial co
 
 When your partial configuration is ready to be used, it has to be _finalised_. For that we use the `finalise` function, which, for our purposes, can be thought of as having the type `finalise :: ConfigPart -> Either [String] Config`, i.e., if the partial configuration had all the options set, we will get a final configuration (where options are guaranteed not to be missing), or if some options were missing we will get a list of their names.
 
+### Trees and branches
+
+`tree`s allow you to define multiple possible configuration to pick from, similarly to Sum-Types.
+You can define several `branch`es and only need to fully populate the one you select, but you can have the others as options until you `finalise` the `tree`
+
+To `finalise` a `tree` you will need to set a selection `option`, this is present in every `tree`, has the automatically generated name of `<tree-name> + "Type"` and will need a `String` value with the chosen `branch`.
+
+So for the example above the "connection" `tree` has a "connectionType" `option` and you could load a Yaml file like:
+
+```yaml
+...
+connection:
+    connectionType: "https"
+    ftpAnon:
+        doRetry: False
+    https:
+        userName: "Serokell"
+...
+```
+
+Please note that a `tree` will need all it's children to be `branch`es, so if you specify another item it will be converted, for instance in the example above we could have specified the "https" "connection" as
+
+```haskell
+...
+         , https ::: String
+...
+```
+
+but that would have been the same as defining:
+
+```haskell
+...
+         , https ::-
+           '[ https ::: String 
+            ]
+...
+```
 
 ## Access Configuration Options
 
-To access configuration options you can use the `option` and `sub` lenses. For example, here is how to get the hostname:
+To access configuration options you can use the `option`, `sub`, `tree` and `branch` lenses. For example, here is how to get the hostname:
 
 ```haskell
 hostName :: Config -> String
@@ -71,4 +123,6 @@ To make the funny hash symbols work you will have to enable this extension:
 {-# LANGUAGE OverloadedLabels #-}
 ```
 
-By the way, these same two lenses work on partial configurations too, so you can use them to set or adjust options during initialisation, with one major difference: the values they focus on are wrapped into `Maybe` because they can be missing and you can set them or unset, much like with the `at` lens.
+These lenses work on both partial and final configurations, with two major difference:
+- the value of a non-finalized `option` is wrapped into a `Maybe` because they can be missing and you can set them or unset, much like with the `at` lens.
+- the value of a finalized `branch` is wrapped into a `Maybe` because they can be selected or not

--- a/code/config/lib/Loot/Config.hs
+++ b/code/config/lib/Loot/Config.hs
@@ -19,8 +19,9 @@ import Lens.Micro ((?~))
 
 import Loot.Config.CLI
 import Loot.Config.Lens
-import Loot.Config.Record ((:::), (::<), ConfigKind (Final, Partial), ConfigRec, complement,
-                           finalise, finaliseDeferredUnsafe, option, sub, upcast)
+import Loot.Config.Record ((:::), (::<), (::+), (::-), ConfigKind (Final, Partial),
+                           ConfigRec, complement, finalise, finaliseDeferredUnsafe,
+                           option, sub, tree, upcast, branch)
 import Loot.Config.Yaml ()
 
 

--- a/code/config/lib/Loot/Config.hs
+++ b/code/config/lib/Loot/Config.hs
@@ -21,7 +21,7 @@ import Loot.Config.CLI
 import Loot.Config.Lens
 import Loot.Config.Record ((:::), (::<), (::+), (::-), ConfigKind (Final, Partial),
                            ConfigRec, complement, finalise, finaliseDeferredUnsafe,
-                           option, sub, tree, upcast, branch)
+                           option, sub, tree, upcast, branch, selection)
 import Loot.Config.Yaml ()
 
 

--- a/code/config/lib/Loot/Config/CLI.hs
+++ b/code/config/lib/Loot/Config/CLI.hs
@@ -16,13 +16,16 @@ module Loot.Config.CLI
        , (.::)
        , (%::)
        , (.:<)
+       , (.:+)
+       , (.:-)
        ) where
 
 import Data.Vinyl (Label, type (<:), rreplace, rcast)
 import Lens.Micro (ASetter')
 import Options.Applicative (Parser, optional)
 
-import Loot.Config.Record (ConfigKind (Partial), ConfigRec, HasOption, HasSub, option, sub)
+import Loot.Config.Record (ConfigKind (Partial), ConfigRec, HasOption, HasSub,
+                           HasSum, HasBranch, SumSelection, option, sub, tree, branch)
 
 -- | Type for a parser which yields a modifier function instead of a
 -- value
@@ -115,6 +118,26 @@ infixr 6 %::
     -> OptModParser is
 l .:< p = (\uf cfg -> cfg & sub l %~ uf) <$> p
 infixr 6 .:<
+
+-- | Combinator which declares a config parser which parses one
+-- tree, leaving other options empty.
+(.:+)
+    :: forall l is us ms. (HasSum l is ms, us ~ (SumSelection l : ms))
+    => Label l
+    -> OptModParser us
+    -> OptModParser is
+l .:+ p = (\uf cfg -> cfg & tree l %~ uf) <$> p
+infixr 6 .:+
+
+-- | Combinator which declares a config parser which parses one
+-- branch, leaving other options empty.
+(.:-)
+    :: forall l is us. (HasBranch l is us)
+    => Label l
+    -> OptModParser us
+    -> OptModParser is
+l .:- p = (\uf cfg -> cfg & branch l %~ uf) <$> p
+infixr 6 .:-
 
 -- | Lifts the modifier of a subconfig to a modifier of larger config.
 uplift

--- a/code/config/lib/Loot/Config/Lens.hs
+++ b/code/config/lib/Loot/Config/Lens.hs
@@ -36,13 +36,16 @@ type family DoesntHaveType f is :: Constraint where
     DoesntHaveType f ((_ ::: f)  ': is) = TypeError ('Text "DoesntHaveType failed (item type not unique?)")
     DoesntHaveType f ((_ ::: _)  ': is) = DoesntHaveType f is
     DoesntHaveType f ((_ ::< us) ': is) = (DoesntHaveType f us, DoesntHaveType f is)
+    DoesntHaveType f ((_ ::+ us) ': is) = (DoesntHaveType f us, DoesntHaveType f is)
+    DoesntHaveType f ((_ ::- us) ': is) = (DoesntHaveType f us, DoesntHaveType f is)
 
 type family ItemTypeUnique (f :: Type) (is :: [ItemKind]) :: Constraint where
     ItemTypeUnique _ '[]       = ()
     ItemTypeUnique f ((_ ::: f) ': is) = DoesntHaveType f is
     ItemTypeUnique f ((_ ::: _) ': is) = ItemTypeUnique f is
     ItemTypeUnique f ((_ ::< us) ': is) = ItemTypeUnique f (us ++ is)
-
+    ItemTypeUnique f ((_ ::+ us) ': is) = ItemTypeUnique f (us ++ is)
+    ItemTypeUnique f ((_ ::- us) ': is) = ItemTypeUnique f (us ++ is)
 
 data SymPathElem = SOption Symbol | SSub Symbol
 
@@ -60,6 +63,12 @@ type family LabelOfType (f :: Type) labels cont (is :: [ItemKind]) :: [SymPathEl
         LabelOfType f labels cont is
 
     LabelOfType f labels cont ((l ::< us) ': is) =
+        LabelOfType f ('SSub l ': labels) (is ': cont) us
+
+    LabelOfType f labels cont ((l ::+ us) ': is) =
+        LabelOfType f ('SSub l ': labels) (is ': cont) us
+
+    LabelOfType f labels cont ((l ::- us) ': is) =
         LabelOfType f ('SSub l ': labels) (is ': cont) us
 
 type family LabelOfTypeS f is where

--- a/code/config/lib/Loot/Config/Yaml.hs
+++ b/code/config/lib/Loot/Config/Yaml.hs
@@ -19,8 +19,8 @@ import Data.Vinyl (Rec ((:&), RNil))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 
 import Loot.Config.Record ((:::), (::<), (::+), (::-), ConfigKind (Partial),
-                           ConfigRec, Item (ItemOptionP, ItemSub, ItemSumP, ItemBranchP), 
-                           ItemKind, SumSelection, ToBranches)
+                           ConfigRec, Item (ItemOptionP, ItemSub, ItemSumP, ItemBranchP),
+                           ItemKind, SumSelection)
 
 
 -- | This class is almost like 'FromJSON' but uses @aeson-better-errors@.
@@ -59,8 +59,8 @@ instance
 instance
     forall l us is.
         ( KnownSymbol l
-        , Monoid (ConfigRec 'Partial (SumSelection l : ToBranches us))
-        , OptionsFromJson (SumSelection l : ToBranches us)
+        , Monoid (ConfigRec 'Partial (SumSelection l : us))
+        , OptionsFromJson (SumSelection l : us)
         , OptionsFromJson is
         )
     => OptionsFromJson ((l ::+ us) ': is)


### PR DESCRIPTION
This PR adds structures in `loot-config` similar to sum-types with the intention of supersede them in config contexts.

The changes in the README, and the comments added should explain the basics of how it works, I'm of course available to provide further explanations.

I uploaded this so reviews can start, but it is labeled as a WIP because I'd like to try to improve it some more or some things may need to be changed heavily, in particular:
- I'd like for the type system to be more aware of the fact that `tree`s only contain `branches`, this would make it more robust and simplify some code, by removing unnecessary checks, but I'm not sure how (or if, really) it can be done
- or ... not. One thing worth considering IMHO is that, somewhat differently from sum-types, `tree`s could also have `option`s/`sub`s that are common and will be used in any case *and* `branch`es that only have the differences
- Some more "smart" lenses could really come in handy, to more easily set/use `branch`es (in particular the selected one) especially after they have been `finalise`d and are inside `Maybe`s
- I tested this and it works as expected, but I did not add proper tests for this yet because it may need to be modified a lot. Old tests still work because the changes are only incremental.