### PR TITLE
[LTB-52] Remove tag in `HasLens` typeclass

### DIFF
--- a/code/base/lib/Loot/Base/HasLens.hs
+++ b/code/base/lib/Loot/Base/HasLens.hs
@@ -1,33 +1,31 @@
 {-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE ConstraintKinds     #-}
 {-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DefaultSignatures   #-}
 {-# LANGUAGE TypeFamilies        #-}
 {-# LANGUAGE TypeOperators       #-}
 
 -- | Basic "has" lenses, extracted from the 'ether' package.
 module Loot.Base.HasLens
-    ( HasLens(..)
-    , HasLens'
+    ( HasLens (lensOf)
     , HasLenses
     , HasCtx
+    , glensOf
     ) where
 
-import Data.Coerce (coerce)
-import Data.Tagged (Tagged (..))
+-- | Class for those @s@ that contain a modifiable @a@ in them.
+class HasLens s a where
+    lensOf :: Lens' s a
 
-class HasLens tag outer inner | tag outer -> inner where
-    lensOf :: Lens' outer inner
-
-instance HasLens a a a where
+instance HasLens a a where
     lensOf = id
-
-instance HasLens t (Tagged t a) a where
-    lensOf = \f -> fmap coerce . f . coerce
-
-type HasLens' s a = HasLens a s a
 
 type family HasLenses s as :: Constraint where
     HasLenses s '[] = ()
-    HasLenses s (a : as) = (HasLens' s a, HasLenses s as)
+    HasLenses s (a : as) = (HasLens s a, HasLenses s as)
 
 type HasCtx ctx m subs = (MonadReader ctx m, HasLenses ctx subs)
+
+-- | A flexible variation of 'lensOf' parametrised in a phantom type.
+glensOf :: forall tag c ctx. HasLens ctx (c tag) => Lens' ctx (c tag)
+glensOf = lensOf

--- a/code/base/package.yaml
+++ b/code/base/package.yaml
@@ -6,6 +6,7 @@ library:
   <<: *lib-common
 
   dependencies:
+    - microlens
     - tagged
 
 tests:

--- a/code/config/lib/Loot/Config/Lens.hs
+++ b/code/config/lib/Loot/Config/Lens.hs
@@ -91,11 +91,10 @@ instance (HasSub l is us, HierarchyLens lx us v) =>
 -- HasLens Instance
 ----------------------------------------------------------------------------
 
-instance
-         ( ItemTypeUnique v is
+instance ( ItemTypeUnique v is
          , HierarchyLens (LabelOfTypeS v is) is v
          ) =>
-         HasLens v (ConfigRec 'Final is) v where
+         HasLens (ConfigRec 'Final is) v where
     lensOf = hlens @(LabelOfTypeS v is)
 
 -- | Like 'HasLens', but with record key.

--- a/code/log/lib/Loot/Log/Internal.hs
+++ b/code/log/lib/Loot/Log/Internal.hs
@@ -5,5 +5,5 @@ module Loot.Log.Internal
        ) where
 
 import Loot.Log.Internal.Logging
-import Loot.Log.Internal.Name
 import Loot.Log.Internal.Message
+import Loot.Log.Internal.Name

--- a/code/log/lib/Loot/Log/Rio.hs
+++ b/code/log/lib/Loot/Log/Rio.hs
@@ -10,9 +10,9 @@ module Loot.Log.Rio
     ) where
 
 import Lens.Micro (to)
-import Loot.Base.HasLens (HasLens', lensOf)
+import Loot.Base.HasLens (HasLens, lensOf)
 
-import Loot.Log.Internal (Logging (..), NameSelector, logNameSelL, Message (..))
+import Loot.Log.Internal (Logging (..), Message (..), NameSelector, logNameSelL)
 
 -- | We provide default implementations for @LoggingIO@ because it facilitates
 -- movement of logging capability between different monads (and also we will
@@ -23,24 +23,24 @@ type LoggingIO = Logging IO
 -- | Default implementation of 'MonadLogging.log' (generated with 'makeCap').
 defaultLog
     :: forall m ctx.
-       (HasLens' ctx LoggingIO, MonadReader ctx m, MonadIO m)
+       (HasLens ctx LoggingIO, MonadReader ctx m, MonadIO m)
     => Message -> m ()
 defaultLog msg = do
-    lg <- view (lensOf @LoggingIO . to _log) <$> ask
+    lg <- view (lensOf . to _log) <$> ask
     liftIO $ lg msg
 
 -- | Default implementation of 'MonadLogging.logName' (generated with
 -- 'makeCap').
 defaultLogName
     :: forall m ctx.
-       (HasLens' ctx LoggingIO, MonadReader ctx m, MonadIO m)
+       (HasLens ctx LoggingIO, MonadReader ctx m, MonadIO m)
     => m NameSelector
-defaultLogName = view (lensOf @LoggingIO) >>= liftIO . _logName
+defaultLogName = view lensOf >>= liftIO . _logName
 
 -- | Default implementation of 'modifyLogNameSel' method.
 defaultModifyLogNameSel
     :: forall m ctx a.
-       (HasLens' ctx LoggingIO, MonadReader ctx m)
+       (HasLens ctx LoggingIO, MonadReader ctx m)
     => (NameSelector -> NameSelector) -> m a -> m a
 defaultModifyLogNameSel f =
-    local (lensOf @LoggingIO . logNameSelL %~ f)
+    local (lensOf @_ @LoggingIO . logNameSelL %~ f)

--- a/code/network/lib/Loot/Network/Example.hs
+++ b/code/network/lib/Loot/Network/Example.hs
@@ -36,13 +36,13 @@ data BigState = BigState
 makeLenses ''BigState
 
 
-instance HasLens ZTNetCliEnv BigState ZTNetCliEnv where
+instance HasLens BigState ZTNetCliEnv where
     lensOf = bsCli
 
-instance HasLens ZTNetServEnv BigState ZTNetServEnv where
+instance HasLens BigState ZTNetServEnv where
     lensOf = bsServ
 
-instance HasLens ZTGlobalEnv BigState ZTGlobalEnv where
+instance HasLens BigState ZTGlobalEnv where
     lensOf = bsCtx
 
 type Env a = ReaderT BigState IO a

--- a/code/network/lib/Loot/Network/ZMQ/Client.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Client.hs
@@ -35,7 +35,7 @@ import qualified Text.Show as T
 
 import qualified System.ZMQ4 as Z
 
-import Loot.Base.HasLens (HasLens (..), HasLens')
+import Loot.Base.HasLens (HasLens (..))
 import Loot.Log.Internal (Logging (..), NameSelector (..), Severity (..), logNameSelL)
 import Loot.Network.Class hiding (NetworkingCli (..), NetworkingServ (..))
 import Loot.Network.Utils (TimeDurationMs (..), getCurrentTimeMs, whileM)
@@ -484,14 +484,14 @@ instance Show CliBrokerStmRes where
 
 runBroker ::
        ( MonadReader r m
-       , HasLens' r ZTNetCliEnv
-       , HasLens' r ZTGlobalEnv
+       , HasLens r ZTNetCliEnv
+       , HasLens r ZTGlobalEnv
        , MonadIO m
        )
     => m ()
 runBroker = do
-    gEnv@ZTGlobalEnv{..} <- view $ lensOf @ZTGlobalEnv
-    cEnv@ZTNetCliEnv{..} <- view $ lensOf @ZTNetCliEnv
+    gEnv@ZTGlobalEnv{..} <- view lensOf
+    cEnv@ZTNetCliEnv{..} <- view lensOf
 
     let ztCliLog = ztLog ztCliLogging
 
@@ -634,9 +634,9 @@ runBroker = do
 
 -- | Retrieve peers we're connected to.
 getPeers ::
-       (MonadReader r m, HasLens' r ZTNetCliEnv, MonadIO m) => m (Set ZTNodeId)
+       (MonadReader r m, HasLens r ZTNetCliEnv, MonadIO m) => m (Set ZTNodeId)
 getPeers = do
-    peersVar <- ztPeers <$> view (lensOf @ZTNetCliEnv)
+    peersVar <- ztPeers <$> view lensOf
     Set.fromList . HMap.keys <$> readTVarIO peersVar
 
 -- | Register a new client.

--- a/code/network/lib/Loot/Network/ZMQ/Instance.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Instance.hs
@@ -18,7 +18,7 @@ module Loot.Network.ZMQ.Instance
     , registerListenerDefault
     ) where
 
-import Loot.Base.HasLens (HasLens (..), HasLens')
+import Loot.Base.HasLens (HasLens (..))
 import qualified Loot.Network.Class as C
 import qualified Loot.Network.ZMQ.Client as ZC
 import Loot.Network.ZMQ.Common (ZTGlobalEnv, ZTNodeId)
@@ -30,36 +30,36 @@ type ReaderIOM r m = (MonadReader r m, MonadIO m)
 -- Client
 ----------------------------------------------------------------------------
 
-runClientDefault :: (ReaderIOM r m, HasLens' r ZC.ZTNetCliEnv, HasLens' r ZTGlobalEnv) => m ()
+runClientDefault :: (ReaderIOM r m, HasLens r ZC.ZTNetCliEnv, HasLens r ZTGlobalEnv) => m ()
 runClientDefault = ZC.runBroker
 
-getPeersDefault :: (ReaderIOM r m, HasLens' r ZC.ZTNetCliEnv) => m (Set ZTNodeId)
+getPeersDefault :: (ReaderIOM r m, HasLens r ZC.ZTNetCliEnv) => m (Set ZTNodeId)
 getPeersDefault = ZC.getPeers
 
-updatePeersDefault :: (ReaderIOM r m, HasLens' r ZC.ZTNetCliEnv) => ZC.ZTUpdatePeersReq -> m ()
+updatePeersDefault :: (ReaderIOM r m, HasLens r ZC.ZTNetCliEnv) => ZC.ZTUpdatePeersReq -> m ()
 updatePeersDefault x = do
-    q <- ZC.ztCliRequestQueue <$> view (lensOf @ZC.ZTNetCliEnv)
+    q <- ZC.ztCliRequestQueue <$> view lensOf
     ZC.updatePeers q x
 
 registerClientDefault ::
-       (ReaderIOM r m, HasLens' r ZC.ZTNetCliEnv)
+       (ReaderIOM r m, HasLens r ZC.ZTNetCliEnv)
     => C.ClientId
     -> Set C.MsgType
     -> Set C.Subscription
     -> m ZC.ZTClientEnv
 registerClientDefault c m s = do
-    q <- ZC.ztCliRequestQueue <$> view (lensOf @ZC.ZTNetCliEnv)
+    q <- ZC.ztCliRequestQueue <$> view lensOf
     ZC.registerClient q c m s
 
 ----------------------------------------------------------------------------
 -- Server
 ----------------------------------------------------------------------------
 
-runServerDefault :: (ReaderIOM r m, HasLens' r ZS.ZTNetServEnv) => m ()
+runServerDefault :: (ReaderIOM r m, HasLens r ZS.ZTNetServEnv) => m ()
 runServerDefault = ZS.runBroker
 
 registerListenerDefault ::
-       (ReaderIOM r m, HasLens' r ZS.ZTNetServEnv)
+       (ReaderIOM r m, HasLens r ZS.ZTNetServEnv)
     => C.ListenerId
     -> Set C.MsgType
     -> m ZS.ZTListenerEnv

--- a/code/network/lib/Loot/Network/ZMQ/Server.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Server.hs
@@ -30,7 +30,7 @@ import qualified Text.Show as T
 
 import qualified System.ZMQ4 as Z
 
-import Loot.Base.HasLens (HasLens (..), HasLens')
+import Loot.Base.HasLens (HasLens (..))
 import Loot.Log.Internal (Logging (..), NameSelector (..), Severity (..), logNameSelL)
 import Loot.Network.BiTQueue (newBtq)
 import Loot.Network.Class hiding (registerListener)
@@ -179,9 +179,9 @@ resolveSocketIndex i
     | i == 2 = ListenersSocket
     | otherwise = error "couldn't resolve polling socket index"
 
-runBroker :: (MonadReader r m, HasLens' r ZTNetServEnv, MonadIO m) => m ()
+runBroker :: (MonadReader r m, HasLens r ZTNetServEnv, MonadIO m) => m ()
 runBroker = do
-    sEnv@ZTNetServEnv{..} <- view $ lensOf @ZTNetServEnv
+    sEnv@ZTNetServEnv{..} <- view lensOf
 
     let publish k v =
             Z.sendMulti ztServPub $ NE.fromList $ [unSubscription k] ++ v
@@ -259,10 +259,10 @@ runBroker = do
                     threadDelay 2000000)
 
 registerListener ::
-       (MonadReader r m, HasLens' r ZTNetServEnv, MonadIO m)
+       (MonadReader r m, HasLens r ZTNetServEnv, MonadIO m)
     => ListenerId -> Set MsgType -> m ZTListenerEnv
 registerListener lName msgTypes = do
-    servRequestQueue <- ztServRequestQueue <$> view (lensOf @ZTNetServEnv)
+    servRequestQueue <- ztServRequestQueue <$> view lensOf
     liftIO $ do
         biTQueue <- newBtq
         iqSend servRequestQueue $ IRRegister lName msgTypes biTQueue


### PR DESCRIPTION
During our work in Disciplina project, we haven't encountered a case when the tag parameter was useful.
When one wants to distinguish between two entities of the same type, adding a phantom
type parameter to types of that entities is usually a better way.

This PR is part #28 with the only changes which we need in Disciplina.