### PR TITLE
[DSCP-457] Fix improper termination

### DIFF
--- a/code/network/lib/Loot/Network/ZMQ/Client.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Client.hs
@@ -40,6 +40,7 @@ import Loot.Log.Internal (Logging (..), NameSelector (..), Severity (..), logNam
 import Loot.Network.Class hiding (NetworkingCli (..), NetworkingServ (..))
 import Loot.Network.Utils (TimeDurationMs (..), getCurrentTimeMs, whileM)
 import Loot.Network.ZMQ.Common
+import Loot.Network.ZMQ.Internal
 import Loot.Network.ZMQ.InternalQueue
 
 ----------------------------------------------------------------------------
@@ -611,7 +612,6 @@ runBroker = do
     liftIO $ withWorkers $ do
       let action = do
               cpd@CliPollData{..} <- atomically $ readTVar ztCliPollData
-
               events <- Z.poll (-1) cpdPolls
               forM_ (events `zip` [0..]) $ \(e,i) ->
                   unless (null e) $ case resolveSocketIndex i cpd of

--- a/code/network/lib/Loot/Network/ZMQ/Client.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Client.hs
@@ -333,6 +333,9 @@ termNetCliEnv ZTNetCliEnv{..} = liftIO $ do
     peersResources <- atomically $ HMap.elems <$> readTVar ztPeers
     forM_ peersResources releasePeerResource
 
+    releaseInternalQueue ztClientsQueue
+    releaseInternalQueue ztCliRequestQueue
+
 -- Connects/disconnects peers at request.
 changePeers :: MonadIO m => ZTGlobalEnv -> ZTNetCliEnv -> ZTUpdatePeersReq -> m ()
 changePeers ZTGlobalEnv{..} ZTNetCliEnv{..} req = liftIO $ do

--- a/code/network/lib/Loot/Network/ZMQ/Internal.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Internal.hs
@@ -1,0 +1,43 @@
+-- | Internal ZMQ-related utilities.
+
+module Loot.Network.ZMQ.Internal
+    ( ztLog
+    , canReceive
+    , atLeastOne
+    , heartbeatSubscription
+    ) where
+
+import Prelude hiding (log)
+
+import Control.Monad.STM (retry)
+import qualified Data.List.NonEmpty as NE
+import GHC.Stack (HasCallStack, callStack)
+import qualified System.ZMQ4 as Z
+
+import Loot.Log.Internal (Logging (..), Message (..), Severity, selectLogName)
+import Loot.Network.Class (Subscription (..))
+
+
+-- | Logging function for zmq -- doesn't require any monad, uses
+-- 'Logging IO' directly.
+ztLog :: HasCallStack => Logging IO -> Severity -> Text -> IO ()
+ztLog Logging{..} msgSeverity msgContent = do
+    msgName <- selectLogName callStack <$> _logName
+    _log $ Message {..}
+
+-- | Checks if data can be received from the socket. Use @whileM
+-- canReceive process@ pattern after the STM action on the needed
+-- socket.
+canReceive :: Z.Socket t -> IO Bool
+canReceive sock = elem Z.In <$> Z.events sock
+
+-- | Given a set of STM actions, returns all that succeed if at least
+-- one does.
+atLeastOne :: NonEmpty (STM (Maybe a)) -> STM (NonEmpty a)
+atLeastOne l = fmap catMaybes (sequence (NE.toList l)) >>= \case
+    [] -> retry
+    x:xs -> pure $ x :| xs
+
+-- | Key for the heartbeat subscription.
+heartbeatSubscription :: Subscription
+heartbeatSubscription = Subscription "_hb"

--- a/code/network/lib/Loot/Network/ZMQ/InternalQueue.hs
+++ b/code/network/lib/Loot/Network/ZMQ/InternalQueue.hs
@@ -3,6 +3,7 @@
 module Loot.Network.ZMQ.InternalQueue
     ( InternalQueue (..)
     , newInternalQueue
+    , releaseInternalQueue
     , iqSend
     , iqReceive
     ) where
@@ -43,6 +44,12 @@ newInternalQueue ztContext = do
     iqTQueue <- newTQueueIO
 
     pure InternalQueue{..}
+
+-- | Releases the internal queue.
+releaseInternalQueue :: InternalQueue t -> IO ()
+releaseInternalQueue InternalQueue{..} = do
+    Z.close iqIn
+    Z.close iqOut
 
 -- | Sends message to the internal queue.
 iqSend :: InternalQueue t -> t -> IO ()

--- a/code/network/lib/Loot/Network/ZMQ/Server.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Server.hs
@@ -155,6 +155,8 @@ termNetServEnv :: MonadIO m => ZTNetServEnv -> m ()
 termNetServEnv ZTNetServEnv{..} = liftIO $ do
     Z.close ztServFront
     Z.close ztServPub
+    releaseInternalQueue ztListenersQueue
+    releaseInternalQueue ztServRequestQueue
 
 data ServBrokerStmRes
     = SBListener ListenerId ZTServSendMsg

--- a/code/network/lib/Loot/Network/ZMQ/Server.hs
+++ b/code/network/lib/Loot/Network/ZMQ/Server.hs
@@ -36,6 +36,7 @@ import Loot.Network.BiTQueue (newBtq)
 import Loot.Network.Class hiding (registerListener)
 import Loot.Network.Utils (whileM)
 import Loot.Network.ZMQ.Common
+import Loot.Network.ZMQ.Internal
 import Loot.Network.ZMQ.InternalQueue
 
 ----------------------------------------------------------------------------

--- a/code/network/package.yaml
+++ b/code/network/package.yaml
@@ -17,6 +17,7 @@ library:
     - loot-base
     - loot-log
     - mtl
+    - safe-exceptions
     - serialise
     - singletons
     - stm

--- a/stack.yaml
+++ b/stack.yaml
@@ -13,6 +13,9 @@ extra-deps:
   - co-log-core
   - co-log
 
+- git: https://github.com/serokell/zeromq-haskell
+  commit: 714ac20981b2d346609fd896a1af4d31eb6d1162
+
 - git: https://github.com/serokell/co-log-sys.git
   commit: a699c4eb00e413eb3cb2e9b34bfc7c1451b21279
 


### PR DESCRIPTION
This PR introduces changes that are better to be reviewed per commit:
* Added `InternalQueue` termination to cli/serv termination functions.
* Use the poll fix from https://github.com/serokell/zeromq-haskell/commit/714ac20981b2d346609fd896a1af4d31eb6d1162
* Do not terminate cli/serv resources before broker exits (this leads to socket operations on the closed sockets)
* Cosmetics: `Internal` module and extra examples