### PR TITLE
[LTB-56] log: Prohibit loggin to stdout

### DIFF
--- a/code/log/lib/Loot/Log/CPS.hs
+++ b/code/log/lib/Loot/Log/CPS.hs
@@ -44,7 +44,6 @@ withConfigAction LogConfig {..} = runCont $
     cfilter predicate <$> cont (withLogCombined $ map makeContAction backends)
   where
     makeContAction = \case
-        StdOut -> withLogMessageStdout
         StdErr -> withLogMessageStderr
         File path -> withLogMessageFile path
         Syslog syslogConfig -> withLogMessageSyslog syslogConfig

--- a/code/log/lib/Loot/Log/Component.hs
+++ b/code/log/lib/Loot/Log/Component.hs
@@ -27,7 +27,6 @@ allocateLogging LogConfig {..} nameSel = do
 
 allocateBackend :: MonadIO m => Int -> BackendConfig -> ComponentM (LogAction m Message)
 allocateBackend n = \case
-    StdOut -> buildComponent_ (buildName "stdout") $ pure logMessageStdout
     StdErr -> buildComponent_ (buildName "stderr") $ pure logMessageStderr
     File path -> logMessageFile <$>
         buildComponent (buildName "file") (openFile path AppendMode) hClose

--- a/code/log/lib/Loot/Log/Config.hs
+++ b/code/log/lib/Loot/Log/Config.hs
@@ -25,15 +25,14 @@ data LogConfig = LogConfig
     } deriving (Show, Eq)
 
 data BackendConfig
-    = StdOut
-    | StdErr
+    = StdErr
     | File FilePath
     | Syslog SyslogConfig
     deriving (Show, Eq)
 
 -- | Basic configuration: just prints log messages to stdout, without filtering
 basicConfig :: LogConfig
-basicConfig = LogConfig [StdOut] Debug
+basicConfig = LogConfig [StdErr] Debug
 
 -- | Loads a 'LogConfig' from a Yaml file. Returns 'basicConfig' is something
 -- goes wrong. It's equivalent to do: 'loadConfigDefault' 'basicConfig'
@@ -53,7 +52,7 @@ loadConfigDefault defaultConfig filePath =
 
 instance FromJSON LogConfig where
     parseJSON = withObject "LogConfig" $ \v -> LogConfig
-        <$> v .:? "backends"     .!= [StdOut]
+        <$> v .:? "backends"     .!= [StdErr]
         <*> v .:? "min-severity" .!= Debug
 
 instance ToJSON LogConfig where
@@ -66,7 +65,6 @@ instance FromJSON BackendConfig where
     parseJSON = withObject "BackendConfig" $ \v -> do
         destType <- v .: "type"
         case destType :: Text of
-            "stdout" -> return StdOut
             "stderr" -> return StdErr
             "file" -> File <$> v .: "path"
             "syslog" -> Syslog <$> parseJSON (Object v) -- short-circuiting: it will 
@@ -75,9 +73,6 @@ instance FromJSON BackendConfig where
 
 instance ToJSON BackendConfig where
     toJSON = \case
-        StdOut -> object
-            [ "type" .= ("stdout" :: Text)
-            ]
         StdErr -> object
             [ "type" .= ("stderr" :: Text)
             ]


### PR DESCRIPTION
PSA: If you use `loot-log` in your project and configure it log to stdout or use `basicConfig` and rely on the fact that it logs to stdout, then you are in big trouble. FTR, if you don’t use `loot-log` in your project, then you are in trouble as well.