### PR TITLE
loot-log: Fix haddock generation

### DIFF
--- a/code/log/lib/Loot/Log/Config.hs
+++ b/code/log/lib/Loot/Log/Config.hs
@@ -99,7 +99,8 @@ instance Semigroup LogConfig where
 instance Monoid LogConfig where
     mempty = LogConfig
         { backends    = []
-        , minSeverity = Emergency
-        -- ^ the highest severity, so that the 'Monoid' laws are satisfied
+        , minSeverity =
+            -- the highest severity, so that the 'Monoid' laws are satisfied
+            Emergency
         }
     mappend = (<>)


### PR DESCRIPTION
Problem: Previously, building the haddocks would fail due to a parse
error caused by a misplaced haddock comment.

Solution: Turn the haddock comment into a regular comment.