### PR TITLE
Add ToJSON instance for config file

### DIFF
--- a/code/config/lib/Loot/Config/Record.hs
+++ b/code/config/lib/Loot/Config/Record.hs
@@ -33,6 +33,8 @@ module Loot.Config.Record
 
        , ItemType
 
+       , LabelsKnown
+
        , finalise
        , finaliseDeferredUnsafe
        , complement
@@ -55,7 +57,7 @@ module Loot.Config.Record
 
 import Data.Default (Default (..))
 import Data.Validation (Validation (Failure, Success), toEither)
-import Data.Vinyl (Label, Rec ((:&), RNil))
+import Data.Vinyl (Label, Rec (RNil, (:&)))
 import Data.Vinyl.Lens (RecElem, rlens, rreplace, type (<:))
 import Data.Vinyl.TypeLevel (RIndex)
 import GHC.TypeLits (AppendSymbol, ErrorMessage ((:<>:), ShowType, Text),

--- a/code/config/lib/Loot/Config/Yaml.hs
+++ b/code/config/lib/Loot/Config/Yaml.hs
@@ -2,26 +2,31 @@
 
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
+{-# LANGUAGE AllowAmbiguousTypes  #-}
 {-# LANGUAGE DataKinds            #-}
-{-# LANGUAGE KindSignatures       #-}
+{-# LANGUAGE TypeFamilies         #-}
 {-# LANGUAGE TypeOperators        #-}
 {-# LANGUAGE UndecidableInstances #-}
-{-# LANGUAGE MonoLocalBinds       #-}
 
--- | Utilities for reading configuration from a file.
+-- | Utilities for parsing and serializing configuration with Yaml/JSON.
 module Loot.Config.Yaml
        ( configParser
        ) where
 
-import Data.Aeson (FromJSON (parseJSON))
+import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object))
 import Data.Aeson.BetterErrors (Parse, fromAesonParser, keyMay, keyOrDefault, toAesonParser')
-import Data.Vinyl (Rec ((:&), RNil))
+import Data.Aeson.Types (Object)
+import Data.Vinyl (Rec (RNil, (:&)))
 import GHC.TypeLits (KnownSymbol, symbolVal)
 
-import Loot.Config.Record ((:::), (::<), (::+), (::-), ConfigKind (Partial),
-                           ConfigRec, Item (ItemOptionP, ItemSub, ItemSumP, ItemBranchP),
-                           ItemKind, SumSelection)
+import qualified Data.HashMap.Strict as HM
 
+import Loot.Config.Record ((:::), (::<), (::+), (::-), ConfigKind (..),
+                           ConfigRec, Item (..), ItemKind, SumSelection)
+
+-- | Helper function to get config key from type level
+getConfigKey :: forall l . KnownSymbol l => Text
+getConfigKey = fromString $ symbolVal (Proxy :: Proxy l)
 
 -- | This class is almost like 'FromJSON' but uses @aeson-better-errors@.
 class OptionsFromJson (is :: [ItemKind]) where
@@ -41,7 +46,7 @@ instance
     configParser = (:&) <$> fmap ItemOptionP parseOption <*> configParser
       where
         parseOption :: Parse e (Maybe v)
-        parseOption = keyMay (fromString $ symbolVal (Proxy :: Proxy l)) fromAesonParser
+        parseOption = keyMay (getConfigKey @l) fromAesonParser
 
 instance
     forall l us is.
@@ -53,7 +58,7 @@ instance
     => OptionsFromJson ((l ::< us) ': is)
   where
     configParser = (:&)
-        <$> fmap ItemSub (parseMulti (Proxy :: Proxy l))
+        <$> fmap ItemSub (parseMulti @l)
         <*> configParser
 
 instance
@@ -66,7 +71,7 @@ instance
     => OptionsFromJson ((l ::+ us) ': is)
   where
     configParser = (:&)
-        <$> fmap ItemSumP (parseMulti (Proxy :: Proxy l))
+        <$> fmap ItemSumP (parseMulti @l)
         <*> configParser
 
 instance
@@ -79,7 +84,7 @@ instance
     => OptionsFromJson ((l ::- us) ': is)
   where
     configParser = (:&)
-        <$> fmap ItemBranchP (parseMulti (Proxy :: Proxy l))
+        <$> fmap ItemBranchP (parseMulti @l)
         <*> configParser
 
 -- | Internal function to parse multiple 'Item's
@@ -89,9 +94,67 @@ parseMulti
         , Monoid (ConfigRec 'Partial us)
         , OptionsFromJson us
         )
-    => Proxy l
-    -> Parse e (ConfigRec 'Partial us)
-parseMulti p = keyOrDefault (fromString $ symbolVal p) mempty configParser
+    => Parse e (ConfigRec 'Partial us)
+parseMulti = keyOrDefault (getConfigKey @l) mempty configParser
 
 instance OptionsFromJson is => FromJSON (ConfigRec 'Partial is) where
     parseJSON = toAesonParser' configParser
+
+-- Helper function to insert values in a JSON 'Object' by config key.
+insert' :: forall l v . (KnownSymbol l, ToJSON v) => v -> Object -> Object
+insert' value = HM.insert (getConfigKey @l) (toJSON value)
+
+-- | This class is helper which converts config to object
+class OptionsToJson (k :: ConfigKind) (is :: [ItemKind]) where
+  -- | Convert 'ConfigRec' to 'Object'
+  configToObject :: ConfigRec k is -> Object
+
+instance OptionsToJson (k :: ConfigKind) '[] where
+  configToObject RNil = HM.empty
+
+instance
+  forall l v is k
+  . ( KnownSymbol l
+    , ToJSON v
+    , OptionsToJson k is
+    )
+  => OptionsToJson k ((l ::: v) ': is) where
+  configToObject (ItemOptionP Nothing :& vs) = configToObject vs
+  configToObject (ItemOptionP (Just v) :& vs) = insert' @l v $ configToObject vs
+  configToObject (ItemOptionF v :& vs) = insert' @l v $ configToObject vs
+
+instance
+  forall l us is k
+  . ( KnownSymbol l
+    , Monoid (ConfigRec 'Partial us)
+    , OptionsToJson k us
+    , OptionsToJson k is
+    )
+  => OptionsToJson k ((l ::< us) ': is) where
+  configToObject (ItemSub v :& vs) = insert' @l v $ configToObject vs
+
+instance
+  forall l us is k
+  . ( KnownSymbol l
+    , Monoid (ConfigRec 'Partial (SumSelection l : us))
+    , OptionsToJson k (SumSelection l : us)
+    , OptionsToJson k is
+    )
+  => OptionsToJson k ((l ::+ us) ': is) where
+  configToObject (ItemSumP v :& vs) = insert' @l v $ configToObject vs
+  configToObject (ItemSumF v :& vs) = insert' @l v $ configToObject vs
+
+instance
+  forall l us is k
+  . ( KnownSymbol l
+    , Monoid (ConfigRec 'Partial us)
+    , OptionsToJson k us
+    , OptionsToJson k is
+    )
+  => OptionsToJson k ((l ::- us) ': is) where
+  configToObject (ItemBranchP v :& vs) = insert' @l v $ configToObject vs
+  configToObject (ItemBranchF Nothing :& vs) = configToObject vs
+  configToObject (ItemBranchF (Just v) :& vs) = insert' @l v $ configToObject vs
+
+instance OptionsToJson k is => ToJSON (ConfigRec k is) where
+  toJSON = Object . configToObject

--- a/code/config/lib/Loot/Config/Yaml.hs
+++ b/code/config/lib/Loot/Config/Yaml.hs
@@ -10,7 +10,8 @@
 
 -- | Utilities for parsing and serializing configuration with Yaml/JSON.
 module Loot.Config.Yaml
-       ( configParser
+       ( OptionsFromJson (..)
+       , OptionsToJson (..)
        ) where
 
 import Data.Aeson (FromJSON (parseJSON), ToJSON (toJSON), Value (Object))

--- a/code/config/loot-config.cabal
+++ b/code/config/loot-config.cabal
@@ -1,10 +1,10 @@
 cabal-version: 1.12
 
--- This file has been generated from package.yaml by hpack version 0.33.0.
+-- This file has been generated from package.yaml by hpack version 0.34.4.
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 6ebb1bd44c4c2e80aacb126114954190d85eada672cfe689b45e287efaf555e5
+-- hash: 307894133adc515bce8125fc12e960451e00e29e69adc56ed0ccbcb45501cb75
 
 name:           loot-config
 version:        0.0.0.0
@@ -34,7 +34,27 @@ library
       Paths_loot_config
   hs-source-dirs:
       lib
-  default-extensions: ApplicativeDo BangPatterns DeriveGeneric FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiWayIf MultiParamTypeClasses NamedFieldPuns OverloadedLabels OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables TemplateHaskell TupleSections TypeApplications ViewPatterns
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiWayIf
+      MultiParamTypeClasses
+      NamedFieldPuns
+      OverloadedLabels
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      ViewPatterns
   ghc-options: -Wall -hide-package base
   build-depends:
       aeson
@@ -45,6 +65,7 @@ library
     , loot-prelude
     , microlens
     , optparse-applicative
+    , unordered-containers
     , validation
     , vinyl
   default-language: Haskell2010
@@ -57,7 +78,27 @@ test-suite loot-base-test
       Paths_loot_config
   hs-source-dirs:
       test
-  default-extensions: ApplicativeDo BangPatterns DeriveGeneric FlexibleContexts FlexibleInstances FunctionalDependencies GeneralizedNewtypeDeriving LambdaCase MultiWayIf MultiParamTypeClasses NamedFieldPuns OverloadedLabels OverloadedStrings RankNTypes RecordWildCards ScopedTypeVariables TemplateHaskell TupleSections TypeApplications ViewPatterns
+  default-extensions:
+      ApplicativeDo
+      BangPatterns
+      DeriveGeneric
+      FlexibleContexts
+      FlexibleInstances
+      FunctionalDependencies
+      GeneralizedNewtypeDeriving
+      LambdaCase
+      MultiWayIf
+      MultiParamTypeClasses
+      NamedFieldPuns
+      OverloadedLabels
+      OverloadedStrings
+      RankNTypes
+      RecordWildCards
+      ScopedTypeVariables
+      TemplateHaskell
+      TupleSections
+      TypeApplications
+      ViewPatterns
   ghc-options: -Wall -hide-package base -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       aeson
@@ -71,4 +112,5 @@ test-suite loot-base-test
     , tasty-discover
     , tasty-hedgehog
     , tasty-hunit
+    , text
   default-language: Haskell2010

--- a/code/config/package.yaml
+++ b/code/config/package.yaml
@@ -12,6 +12,7 @@ library:
     - loot-base
     - microlens
     - optparse-applicative
+    - unordered-containers
     - validation
     - vinyl
 
@@ -30,4 +31,5 @@ tests:
       - tasty-hunit
 
       - aeson
+      - text
       - optparse-applicative


### PR DESCRIPTION
Problem:
We have FromJSON instance so we can parse configuration from valid
json or yaml. But there are cases when we want print this config file,
send, log, etc. So it's useful to have ToJSON instance too.

Solution:
Add ToJSON instance for ConfigRec, converting to json happens with
help of OptionsToJson class which recursively goes through config file
and convert values.

Note: we independently implemented `ToJSON` in this PR before we noticed #53