### PR TITLE
[Chore] Switch to co-log 0.5.0.0

### DIFF
--- a/snapshot.yaml
+++ b/snapshot.yaml
@@ -2,8 +2,10 @@ name: lootbox-snapshot
 resolver: lts-19.21
 
 packages:
+  - co-log-0.5.0.0
   - co-log-sys-0.1.1.0
   - componentm-0.0.0.2
+  - serialise-0.2.6.0
 
   - git: https://github.com/int-index/caps
     commit: a5eaad31dcef6046a8a01a65ec648219d06478ba
@@ -14,21 +16,23 @@ packages:
   - git: https://github.com/serokell/base-noprelude.git
     commit: c8b06c4c8a271fce0c2f41ab18e88d58e64bac52 # 4.15.1.0
 
-  - git: https://github.com/co-log/co-log.git
-    commit: 65b89152d0ae61ac99a56fbe645ed28cfacd717e
   # Required by co-log
-  - chronos-1.1.4
-  - co-log-core-0.3.1.0
+  - chronos-1.1.5
+  - co-log-core-0.3.2.0
   - typerep-map-0.5.0.0
   # Required by chronos
-  - bytebuild-0.3.10.0
-  - byteslice-0.2.7.0
-  - bytesmith-0.3.8.0
+  - bytebuild-0.3.12.0
+  - byteslice-0.2.9.0
+  - bytesmith-0.3.9.1
   # Required by byte*
   - run-st-0.1.1.0
   - zigzag-0.0.1.0
-  - contiguous-0.6.1.1
-  # for componentm
+  - contiguous-0.6.3.0
+  # Required by serialise
+  - cborg-0.2.8.0
+  # Required by cborg and and byteslice
+  - primitive-0.7.4.0
+  # For componentm
   - teardown-0.5.0.1
 
 flags:

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,136 +5,153 @@
 
 packages:
 - completed:
+    hackage: co-log-0.5.0.0@sha256:a7e84650eaef7eba2d59ee7664309e79317a7ca67011abedf971f0e6bd6475bb,5448
+    pantry-tree:
+      sha256: 33b838c07c8b7e70b2e82bddc889bb1e6386d7e12a9d1593c0b4b263b1fcb925
+      size: 1043
+  original:
+    hackage: co-log-0.5.0.0
+- completed:
     hackage: co-log-sys-0.1.1.0@sha256:b9f31bbf78b5bd510264b1fda2cff94877ad093c3cc231ee5b9acb62f313978a,2560
     pantry-tree:
-      size: 657
       sha256: 50fa269833da292ab1b6817bb8664c3f76276a65ff9baa9f38d0e19da90b04e3
+      size: 657
   original:
     hackage: co-log-sys-0.1.1.0
 - completed:
     hackage: componentm-0.0.0.2@sha256:d15df070056810a512183021d95af6fc99a4ff96a26352de4fe46b92ebc84728,2103
     pantry-tree:
-      size: 629
       sha256: eb848cec860eb1588d5197a6e5441d60058aa006be610d2ca7388deac1c912e5
+      size: 629
   original:
     hackage: componentm-0.0.0.2
 - completed:
+    hackage: serialise-0.2.6.0@sha256:c98de52c5758da4dc5141d44bd2195dcd3232ca3aee8ebc4542d348125899a66,8776
+    pantry-tree:
+      sha256: 2300fb595e40c0da1b02f66c5955b42d28459bb48d370f1b2ac67aa0bcf5484a
+      size: 4056
+  original:
+    hackage: serialise-0.2.6.0
+- completed:
+    commit: a5eaad31dcef6046a8a01a65ec648219d06478ba
+    git: https://github.com/int-index/caps
     name: caps
-    version: '0.1'
-    git: https://github.com/int-index/caps
     pantry-tree:
-      size: 438
       sha256: 39fde8e2319cf3b09897dc144fe721e41a943ecac74ef8256fd6ad95b934393b
-    commit: a5eaad31dcef6046a8a01a65ec648219d06478ba
+      size: 438
+    version: '0.1'
   original:
+    commit: a5eaad31dcef6046a8a01a65ec648219d06478ba
     git: https://github.com/int-index/caps
-    commit: a5eaad31dcef6046a8a01a65ec648219d06478ba
 - completed:
+    commit: 714ac20981b2d346609fd896a1af4d31eb6d1162
+    git: https://github.com/serokell/zeromq-haskell
     name: zeromq4-haskell
-    version: 0.7.0
-    git: https://github.com/serokell/zeromq-haskell
     pantry-tree:
-      size: 1549
       sha256: 44af9e65599823ae012cd740e3d5f4874ddeba7f027edf16600be9971f07310d
-    commit: 714ac20981b2d346609fd896a1af4d31eb6d1162
+      size: 1549
+    version: 0.7.0
   original:
+    commit: 714ac20981b2d346609fd896a1af4d31eb6d1162
     git: https://github.com/serokell/zeromq-haskell
-    commit: 714ac20981b2d346609fd896a1af4d31eb6d1162
 - completed:
+    commit: c8b06c4c8a271fce0c2f41ab18e88d58e64bac52
+    git: https://github.com/serokell/base-noprelude.git
     name: base-noprelude
-    version: 4.15.1.0
-    git: https://github.com/serokell/base-noprelude.git
     pantry-tree:
-      size: 823
       sha256: e5379f2f6565ae07b8bfb3da213e5a648edd79ccec000290d0f234b9cb750863
-    commit: c8b06c4c8a271fce0c2f41ab18e88d58e64bac52
+      size: 823
+    version: 4.15.1.0
   original:
+    commit: c8b06c4c8a271fce0c2f41ab18e88d58e64bac52
     git: https://github.com/serokell/base-noprelude.git
-    commit: c8b06c4c8a271fce0c2f41ab18e88d58e64bac52
 - completed:
-    name: co-log
-    version: 0.4.0.2
-    git: https://github.com/co-log/co-log.git
+    hackage: chronos-1.1.5@sha256:116b63db6e79574e7ac50bf12a6303af5dae4048b222c0f78380d24f481abb5a,3696
     pantry-tree:
-      size: 1637
-      sha256: f13e7119483636d37487f0a64de35e4f4bfe275bafc418907e593d57ce588649
-    commit: 65b89152d0ae61ac99a56fbe645ed28cfacd717e
-  original:
-    git: https://github.com/co-log/co-log.git
-    commit: 65b89152d0ae61ac99a56fbe645ed28cfacd717e
-- completed:
-    hackage: chronos-1.1.4@sha256:c51e9c5afce7bb26c01aba10e42f5a29ccafa4a8d6fd9264d68f16419e05ac47,3811
-    pantry-tree:
+      sha256: 0eb2e0874c845e299c2e174144fd37da1a7957fd0055b2b99b33d23a06c7720e
       size: 581
-      sha256: acb417125d8a63a7ddc12a2cac425f8d1d6741fc76b40c0de6bb8d226f731727
   original:
-    hackage: chronos-1.1.4
+    hackage: chronos-1.1.5
 - completed:
-    hackage: co-log-core-0.3.1.0@sha256:9794bdedd1391decd0e22bdfe2b11abcb42e6cff7a4531e1f8882890828f4e63,3816
+    hackage: co-log-core-0.3.2.0@sha256:9b2699adecee2f072b6c713089e675b592ef23f00a2ff3740bdaf4d87de8d456,3850
     pantry-tree:
+      sha256: af9c807ce50a126706bd99983ec71c060a489ab2b914de8dbccf756adccc2a43
       size: 584
-      sha256: d4cc089c40c5052ee02f91eafa567e0a239908aabc561dfa6080ba3bfc8c25bd
   original:
-    hackage: co-log-core-0.3.1.0
+    hackage: co-log-core-0.3.2.0
 - completed:
     hackage: typerep-map-0.5.0.0@sha256:34f1ba9b268a6d52e26ae460011a5571e8099b50a3f4a7c8db25dd8efe3be8ee,4667
     pantry-tree:
-      size: 1487
       sha256: ca5565de307d260dc67f6dae0d4d33eee42a3238183461569b5142ceb909c91d
+      size: 1487
   original:
     hackage: typerep-map-0.5.0.0
 - completed:
-    hackage: bytebuild-0.3.10.0@sha256:c0f3bdbb92cfb48193756366c50193cde23aa7f8292994a9e3a744f5307c6fc1,3213
+    hackage: bytebuild-0.3.12.0@sha256:213a31ad63f6733776f822ff143dff1bc43d3e9672f36c8898aa853c60dd32d9,3411
     pantry-tree:
-      size: 1135
-      sha256: 00da63e842faa2758fa08e1554f30f7cf69b4b1fc4ce84ebedff64542f1fd00f
+      sha256: 6ea6e0cb446258bf23a278402216e4094a3cab7048b31b60d3e878750afaa536
+      size: 1367
   original:
-    hackage: bytebuild-0.3.10.0
+    hackage: bytebuild-0.3.12.0
 - completed:
-    hackage: byteslice-0.2.7.0@sha256:b5aa80e6efa143b532d20603fb643767386771ec059adedd87cf72cceaf96420,2403
+    hackage: byteslice-0.2.9.0@sha256:b9d781040018345533a07d9f7768a648fa190d5b2a3ea6135446e5680f6d8b29,2496
     pantry-tree:
-      size: 1546
-      sha256: d2b3fe36bbabea0225bbce11f9c61a5c81fea7bfb9f742086284e4d0667d1797
+      sha256: 26e3c2ec5cfc5b35c4ec767941b8b66b036fbdde233fd457c00d69cc7cffcbd0
+      size: 1616
   original:
-    hackage: byteslice-0.2.7.0
+    hackage: byteslice-0.2.9.0
 - completed:
-    hackage: bytesmith-0.3.8.0@sha256:c17c0eb6702dfa209b2e5e7496d72f770d0b5dc2adf30da62f611966ebbb69f5,1863
+    hackage: bytesmith-0.3.9.1@sha256:ec061575cd322cb08eded2c64b37ed27f9c62fafb339fefdb5ab39b2e3ff9a62,1951
     pantry-tree:
+      sha256: fe9d2e374543873cf3a5ebc7d6f569f1252d4ca4f27f6901cbd4603b6f072dbc
       size: 1185
-      sha256: a8714bdfd649a717a1fdfa8f0e64c1e1d6f87893b36cdfa605491129e0c1cf04
   original:
-    hackage: bytesmith-0.3.8.0
+    hackage: bytesmith-0.3.9.1
 - completed:
     hackage: run-st-0.1.1.0@sha256:a43245bb23984089016772481bf52bfe63eaff0c5040303f69c9b15e80872fdc,883
     pantry-tree:
-      size: 269
       sha256: 06d5d7ecf185a26c15e48cda6c30e8865dae715c528a31466701272fae36d822
+      size: 269
   original:
     hackage: run-st-0.1.1.0
 - completed:
-    hackage: zigzag-0.0.1.0@sha256:a995158dad3dfe0347cfc8f8a9327cc3f51832600553169ba5b1e08c45b45405,1078
+    hackage: zigzag-0.0.1.0@sha256:ac2f78aa02457ac12d17621c692d29ad30bae205b5be858fbf0e400ac9a9c412,1133
     pantry-tree:
+      sha256: 4d37af24d7d68ca428cc9e8c9e909c3c57417a244b59cffcc54f4004405b7d4e
       size: 321
-      sha256: e5e5aadb11d695f9f1792a6d8f8faa4131afc23713335ff93dab6b0806bea510
   original:
     hackage: zigzag-0.0.1.0
 - completed:
-    hackage: contiguous-0.6.1.1@sha256:10922abbdf6c61cb4a9e493609871c4fd0c47dcde17dba3a6b6c420ef76fc212,1871
+    hackage: contiguous-0.6.3.0@sha256:079cd3284a9f0b9cf33947ba35cb16957baae947b2635ec1758817d386675ef9,1871
     pantry-tree:
+      sha256: 5301ec00ea55586f2fa3f75c8d1fc43f860d09fb5c7b285caf2d100453d965b0
       size: 600
-      sha256: e17834983b11be7cf05fca6a139987bf970634bf8bcf31621cf09d92aaecdd85
   original:
-    hackage: contiguous-0.6.1.1
+    hackage: contiguous-0.6.3.0
+- completed:
+    hackage: cborg-0.2.8.0@sha256:a6778307362f87689afb872c893c28ef4f56eb304428405ad2e5ed4b33d4a28e,5308
+    pantry-tree:
+      sha256: 954d2c66740497e11019007a97d5d940b56a8795787903b26393373fa06d56d4
+      size: 2559
+  original:
+    hackage: cborg-0.2.8.0
+- completed:
+    hackage: primitive-0.7.4.0@sha256:c2f0ed97b3dce97f2f43b239c3be8b136e4368f1eb7b61322ee9ac98f604622b,2982
+    pantry-tree:
+      sha256: 1cd1f40729b3038f1140fbf506ce59ab2db3f745b1727e0beba6390621aa9630
+      size: 1655
+  original:
+    hackage: primitive-0.7.4.0
 - completed:
     hackage: teardown-0.5.0.1@sha256:b7a6812637f79d81632bb7adebc5ad9a96fffacf3e5f655d5bf21728bd3786f9,2868
     pantry-tree:
-      size: 742
       sha256: 386c90aef420c528d67581e2108bacbb648b8ca6d1bbd447e5f3a306db4b236c
+      size: 742
   original:
     hackage: teardown-0.5.0.1
 snapshots:
 - completed:
+    sha256: fe8926aaa3f05bb1a0a82551d2e221f267726fe73ac369d74f7b909d45b92fba
     size: 619391
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/19/21.yaml
-    sha256: fe8926aaa3f05bb1a0a82551d2e221f267726fe73ac369d74f7b909d45b92fba
   original: lts-19.21


### PR DESCRIPTION
Switched to a new co-log version. This also required to specify some `serialise` related dependencies due to a common transitive dependency (`primitive`).

Fixes #59